### PR TITLE
Remove superfluous `features` value

### DIFF
--- a/test/built-ins/TypedArray/Symbol.species/prop-desc.js
+++ b/test/built-ins/TypedArray/Symbol.species/prop-desc.js
@@ -9,7 +9,7 @@ info: >
 
   %TypedArray%[@@species] is an accessor property whose set accessor function
   is undefined.
-features: [TypedArray, Symbol.species]
+features: [Symbol.species]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/Symbol.species/result.js
+++ b/test/built-ins/TypedArray/Symbol.species/result.js
@@ -8,7 +8,7 @@ info: >
   22.2.2.4 get %TypedArray% [ @@species ]
 
   1. Return the this value.
-features: [TypedArray, Symbol.species]
+features: [Symbol.species]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/from/arylk-get-length-error.js
+++ b/test/built-ins/TypedArray/from/arylk-get-length-error.js
@@ -10,7 +10,6 @@ info: >
   12. Let len be ToLength(Get(arrayLike, "length")).
   13. ReturnIfAbrupt(len).
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/from/arylk-to-length-error.js
+++ b/test/built-ins/TypedArray/from/arylk-to-length-error.js
@@ -10,7 +10,7 @@ info: >
   12. Let len be ToLength(Get(arrayLike, "length")).
   13. ReturnIfAbrupt(len).
   ...
-features: [TypedArray, Symbol.toPrimitive]
+features: [Symbol.toPrimitive]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/from/invoked-as-func.js
+++ b/test/built-ins/TypedArray/from/invoked-as-func.js
@@ -10,7 +10,6 @@ info: >
   1. Let C be the this value.
   2. If IsConstructor(C) is false, throw a TypeError exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/from/invoked-as-method.js
+++ b/test/built-ins/TypedArray/from/invoked-as-method.js
@@ -25,7 +25,6 @@ info: >
   ...
   2. If SameValue(%TypedArray%, newTarget) is true, throw a TypeError exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/from/iter-access-error.js
+++ b/test/built-ins/TypedArray/from/iter-access-error.js
@@ -11,7 +11,7 @@ info: >
   6. Let usingIterator be GetMethod(items, @@iterator).
   7. ReturnIfAbrupt(usingIterator).
   ...
-features: [TypedArray, Symbol.iterator]
+features: [Symbol.iterator]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/from/iter-invoke-error.js
+++ b/test/built-ins/TypedArray/from/iter-invoke-error.js
@@ -12,7 +12,7 @@ info: >
     a. Let iterator be GetIterator(items, usingIterator).
     b. ReturnIfAbrupt(iterator).
   ...
-features: [TypedArray, Symbol.iterator]
+features: [Symbol.iterator]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/from/iter-next-error.js
+++ b/test/built-ins/TypedArray/from/iter-next-error.js
@@ -14,7 +14,7 @@ info: >
       i. Let next be IteratorStep(iterator).
       ii. ReturnIfAbrupt(next).
     ...
-features: [TypedArray, Symbol.iterator]
+features: [Symbol.iterator]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/from/iter-next-value-error.js
+++ b/test/built-ins/TypedArray/from/iter-next-value-error.js
@@ -13,7 +13,7 @@ info: >
     e. If next is not false, then
       i. Let nextValue be IteratorValue(next).
       ii. ReturnIfAbrupt(nextValue).
-features: [TypedArray, Symbol.iterator]
+features: [Symbol.iterator]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/from/prop-desc.js
+++ b/test/built-ins/TypedArray/from/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 verifyNotEnumerable(TypedArray, 'from');

--- a/test/built-ins/TypedArray/invoked-as-ctor-with-arguments.js
+++ b/test/built-ins/TypedArray/invoked-as-ctor-with-arguments.js
@@ -14,7 +14,6 @@ info: >
   Note: there's a breaking change from ES2015's 22.2.1.2 step 7 where calling
   the %TypedArray% constructor with a floating number as the argument throws a
   RangeError exception before checking `SameValue(NewTarget, here)`.
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/invoked-as-ctor.js
+++ b/test/built-ins/TypedArray/invoked-as-ctor.js
@@ -9,7 +9,6 @@ info: >
   ...
   2. If SameValue(%TypedArray%, newTarget) is true, throw a TypeError exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/invoked-as-func.js
+++ b/test/built-ins/TypedArray/invoked-as-func.js
@@ -8,7 +8,6 @@ info: >
 
   1. If NewTarget is undefined, throw a TypeError exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/length-invalid.js
+++ b/test/built-ins/TypedArray/length-invalid.js
@@ -13,7 +13,6 @@ info: >
   7. If SameValueZero(numberLength, elementLength) is false, throw a RangeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/length.js
+++ b/test/built-ins/TypedArray/length.js
@@ -15,7 +15,6 @@ info: >
   Function object has the attributes { [[Writable]]: false, [[Enumerable]]:
   false, [[Configurable]]: true }.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 assert.sameValue(TypedArray.length, 3);

--- a/test/built-ins/TypedArray/name.js
+++ b/test/built-ins/TypedArray/name.js
@@ -15,7 +15,6 @@ info: >
   Function object, if it exists, has the attributes { [[Writable]]: false,
   [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 assert.sameValue(TypedArray.name, 'TypedArray');

--- a/test/built-ins/TypedArray/of/invoked-as-func.js
+++ b/test/built-ins/TypedArray/of/invoked-as-func.js
@@ -11,7 +11,6 @@ info: >
   3. Let C be the this value.
   4. If IsConstructor(C) is false, throw a TypeError exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/of/invoked-as-method.js
+++ b/test/built-ins/TypedArray/of/invoked-as-method.js
@@ -17,7 +17,6 @@ info: >
   ...
   2. If SameValue(%TypedArray%, newTarget) is true, throw a TypeError exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/of/prop-desc.js
+++ b/test/built-ins/TypedArray/of/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 verifyNotEnumerable(TypedArray, 'of');

--- a/test/built-ins/TypedArray/prototype.js
+++ b/test/built-ins/TypedArray/prototype.js
@@ -10,7 +10,6 @@ info: >
   This property has the attributes { [[Writable]]: false, [[Enumerable]]:
   false, [[Configurable]]: false }.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 verifyNotEnumerable(TypedArray, 'prototype');

--- a/test/built-ins/TypedArray/prototype/Symbol.toStringTag/invoked-as-accessor.js
+++ b/test/built-ins/TypedArray/prototype/Symbol.toStringTag/invoked-as-accessor.js
@@ -11,7 +11,7 @@ info: >
   ...
   3. If O does not have a [[TypedArrayName]] internal slot, return undefined.
   ...
-features: [TypedArray, Symbol.toStringTag]
+features: [Symbol.toStringTag]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/Symbol.toStringTag/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/Symbol.toStringTag/invoked-as-func.js
@@ -9,7 +9,7 @@ info: >
   1. Let O be the this value.
   2. If Type(O) is not Object, return undefined.
   ...
-features: [TypedArray, Symbol.toStringTag]
+features: [Symbol.toStringTag]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/Symbol.toStringTag/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/Symbol.toStringTag/prop-desc.js
@@ -11,7 +11,6 @@ info: >
   This property has the attributes { [[Enumerable]]: false, [[Configurable]]:
   true }.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/buffer/invoked-as-accessor.js
+++ b/test/built-ins/TypedArray/prototype/buffer/invoked-as-accessor.js
@@ -12,7 +12,6 @@ info: >
   3. If O does not have a [[ViewedArrayBuffer]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/buffer/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/buffer/invoked-as-func.js
@@ -11,7 +11,6 @@ info: >
   3. If O does not have a [[ViewedArrayBuffer]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/buffer/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/buffer/prop-desc.js
@@ -7,7 +7,6 @@ description: >
 info: >
   %TypedArray%.prototype.buffer is an accessor property whose set accessor
   function is undefined.
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/byteLength/invoked-as-accessor.js
+++ b/test/built-ins/TypedArray/prototype/byteLength/invoked-as-accessor.js
@@ -12,7 +12,6 @@ info: >
   3. If O does not have a [[ViewedArrayBuffer]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/byteLength/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/byteLength/invoked-as-func.js
@@ -11,7 +11,6 @@ info: >
   3. If O does not have a [[ViewedArrayBuffer]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/byteLength/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/byteLength/prop-desc.js
@@ -7,7 +7,6 @@ description: >
 info: >
   %TypedArray%.prototype.byteLength is an accessor property whose set accessor
   function is undefined.
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/byteOffset/invoked-as-accessor.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/invoked-as-accessor.js
@@ -12,7 +12,6 @@ info: >
   3. If O does not have a [[ViewedArrayBuffer]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/byteOffset/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/invoked-as-func.js
@@ -11,7 +11,6 @@ info: >
   3. If O does not have a [[ViewedArrayBuffer]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/byteOffset/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/prop-desc.js
@@ -7,7 +7,6 @@ description: >
 info: >
   %TypedArray%.prototype.byteOffset is an accessor property whose set accessor
   function is undefined.
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/copyWithin/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/invoked-as-func.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/copyWithin/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/invoked-as-method.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/copyWithin/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/entries/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/entries/invoked-as-func.js
@@ -19,7 +19,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/entries/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/entries/invoked-as-method.js
@@ -19,7 +19,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/entries/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/entries/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/every/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/every/invoked-as-func.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/every/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/every/invoked-as-method.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/every/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/every/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/fill/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/fill/invoked-as-func.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/fill/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/fill/invoked-as-method.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/fill/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/fill/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/filter/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/filter/invoked-as-func.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/filter/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/filter/invoked-as-method.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/filter/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/filter/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/find/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/find/invoked-as-func.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/find/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/find/invoked-as-method.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/find/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/find/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/findIndex/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/invoked-as-func.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/findIndex/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/invoked-as-method.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/findIndex/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/forEach/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/forEach/invoked-as-func.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/forEach/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/forEach/invoked-as-method.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/forEach/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/forEach/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/indexOf/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/invoked-as-func.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/indexOf/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/invoked-as-method.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/indexOf/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/join/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/join/invoked-as-func.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/join/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/join/invoked-as-method.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/join/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/join/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/keys/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/keys/invoked-as-func.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/keys/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/keys/invoked-as-method.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/keys/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/keys/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/invoked-as-func.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/invoked-as-method.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/length/invoked-as-accessor.js
+++ b/test/built-ins/TypedArray/prototype/length/invoked-as-accessor.js
@@ -12,7 +12,6 @@ info: >
   3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/length/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/length/invoked-as-func.js
@@ -9,7 +9,6 @@ info: >
   1. Let O be the this value.
   2. If Type(O) is not Object, throw a TypeError exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/length/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/length/prop-desc.js
@@ -7,7 +7,6 @@ description: >
 info: >
   %TypedArray%.prototype.length is an accessor property whose set accessor
   function is undefined.
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/map/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/map/invoked-as-func.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/map/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/map/invoked-as-method.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/map/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/map/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/reduce/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/reduce/invoked-as-func.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/reduce/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/reduce/invoked-as-method.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/reduce/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/reduce/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/reduceRight/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/invoked-as-func.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/reduceRight/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/invoked-as-method.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/reduceRight/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/reverse/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/reverse/invoked-as-func.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/reverse/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/reverse/invoked-as-method.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/reverse/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/reverse/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/set/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/set/invoked-as-func.js
@@ -8,7 +8,6 @@ info: >
 
   This function is not generic. The this value must be an object with a
   [[TypedArrayName]] internal slot.
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/set/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/set/invoked-as-method.js
@@ -8,7 +8,6 @@ info: >
 
   This function is not generic. The this value must be an object with a
   [[TypedArrayName]] internal slot.
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/set/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/set/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/slice/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/slice/invoked-as-func.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/slice/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/slice/invoked-as-method.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/slice/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/slice/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/some/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/some/invoked-as-func.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/some/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/some/invoked-as-method.js
@@ -16,7 +16,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/some/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/some/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/sort/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/sort/invoked-as-func.js
@@ -22,7 +22,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/sort/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/sort/invoked-as-method.js
@@ -22,7 +22,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/sort/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/sort/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/subarray/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/subarray/invoked-as-func.js
@@ -11,7 +11,6 @@ info: >
   3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/subarray/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/subarray/invoked-as-method.js
@@ -11,7 +11,6 @@ info: >
   3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/subarray/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/subarray/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/toLocaleString/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/invoked-as-func.js
@@ -18,7 +18,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/toLocaleString/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/invoked-as-method.js
@@ -18,7 +18,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/toLocaleString/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/toString.js
+++ b/test/built-ins/TypedArray/prototype/toString.js
@@ -15,7 +15,6 @@ info: >
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;

--- a/test/built-ins/TypedArray/prototype/values/invoked-as-func.js
+++ b/test/built-ins/TypedArray/prototype/values/invoked-as-func.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/values/invoked-as-method.js
+++ b/test/built-ins/TypedArray/prototype/values/invoked-as-method.js
@@ -17,7 +17,6 @@ info: >
   2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError
   exception.
   ...
-features: [TypedArray]
 includes: [testTypedArray.js]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/values/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/values/prop-desc.js
@@ -9,7 +9,6 @@ info: >
   26 and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js, testTypedArray.js]
-features: [TypedArray]
 ---*/
 
 var TypedArrayPrototype = TypedArray.prototype;


### PR DESCRIPTION
The location of the files makes specifying "TypeArray" in the `features`
tag redundant. From the tag's description in the project's
CONTRIBUTING.md file:

> Some tests require the use of language features that are not directly
> described by the test file's location in the directory structure.
> These features should be formally listed here.

Remove the "TypedArray" feature flag from those files whose location
already communicates that information.
