### PR TITLE
Invoke helper function with appropriate object

### DIFF
--- a/test/built-ins/TypedArrays/internals/GetOwnProperty/detached-buffer-key-is-not-number.js
+++ b/test/built-ins/TypedArrays/internals/GetOwnProperty/detached-buffer-key-is-not-number.js
@@ -20,7 +20,7 @@ features: [Reflect]
 
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA([42, 43]);
-  $DETACHBUFFER(sample);
+  $DETACHBUFFER(sample.buffer);
 
   assert.sameValue(
     Reflect.getOwnPropertyDescriptor(sample, "undef"),

--- a/test/built-ins/TypedArrays/internals/GetOwnProperty/detached-buffer-key-is-symbol.js
+++ b/test/built-ins/TypedArrays/internals/GetOwnProperty/detached-buffer-key-is-symbol.js
@@ -20,7 +20,7 @@ features: [Reflect, Symbol]
 
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA([42, 43]);
-  $DETACHBUFFER(sample);
+  $DETACHBUFFER(sample.buffer);
 
   var s = Symbol("foo");
   Object.defineProperty(sample, s, { value: "baz" });

--- a/test/built-ins/TypedArrays/internals/GetOwnProperty/detached-buffer.js
+++ b/test/built-ins/TypedArrays/internals/GetOwnProperty/detached-buffer.js
@@ -25,7 +25,7 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA(1);
-  $DETACHBUFFER(sample);
+  $DETACHBUFFER(sample.buffer);
 
   assert.throws(TypeError, function() {
     Reflect.getOwnPropertyDescriptor(sample, 0);

--- a/test/built-ins/TypedArrays/internals/HasOwnProperty/detached-buffer.js
+++ b/test/built-ins/TypedArrays/internals/HasOwnProperty/detached-buffer.js
@@ -19,7 +19,7 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA(1);
-  $DETACHBUFFER(sample);
+  $DETACHBUFFER(sample.buffer);
 
   assert.throws(TypeError, function() {
     Reflect.has(sample, "0");


### PR DESCRIPTION
The name and parameter list of the `$DETACHARRAYBUFFER` helper function
suggest that an ArrayBuffer instance is the expected input. Update call
sites to supply such a reference.
